### PR TITLE
Fix information loss on voluntary resquash

### DIFF
--- a/squashfu
+++ b/squashfu
@@ -42,6 +42,7 @@ create_new_squash () {
   # Determine oldest $1 bins and mount them with the current squash
   local old_bins=($(sort -n -r -t: -k2 "$BINVENTORY" | tail -$1 | cut -d: -f1))
 
+  mountpoint -q "$SQUASH_MOUNT" || mount_squash
   mount_union_with_bins ${old_bins[@]}
 
   info "Merging old incrementals"


### PR DESCRIPTION
Thanks for this script, it's really awesome and I use it a lot.

There's a severe bug when using the `-C` switch. The `create_new_squash` function doesn't ensure the current squashfs is mounted on `ro` and the newly created seed doesn't contain any of the information from the original seed.

In most cases this means the bulk of the backup is lost.

The fix is just one line ensuring the seed is mounted before mounting the union.
